### PR TITLE
Fixed image link

### DIFF
--- a/_site/en-US/win10/HWAfeatures.htm
+++ b/_site/en-US/win10/HWAfeatures.htm
@@ -882,7 +882,8 @@
 </code></pre>
 
 <p>This code will produce a tile that looks something like this:
-<img src="../../images/HWA_liveTile.png" alt="Windows Runtime API Live Tile Example" /></p>
+<img src="/WebAppsDocs/images/CreateHWA/HWA_liveTile.png" alt="Windows Runtime API Live Tile Example" />
+</p>
 
 <p>Call Windows Runtime APIs with whatever environment or technique is most familiar to you by keeping your resources on a server feature detecting for Windows capabilities prior to calling them. If platform capabilities are not available, and the web app is running in another host, you can provide the user with a standard default experience that works in the browser.</p>
 


### PR DESCRIPTION
Image link is broken on http://microsoftedge.github.io/WebAppsDocs/en-US//win10/HWAfeatures.htm#call-windows-runtime-apis  ...I believe this will fix the link.