### PR TITLE
Fix code sample color (with build compiling)

### DIFF
--- a/_site/css/main.css
+++ b/_site/css/main.css
@@ -400,5 +400,10 @@ img.horizontal-margin-auto
 }
 .grey-border
 {
-    border: 1px solid grey;
+    border: 1px solid gray;
+}
+
+.highlight 
+{
+    color: gray;
 }

--- a/_site/en-US/win10/HWAfeatures.htm
+++ b/_site/en-US/win10/HWAfeatures.htm
@@ -854,32 +854,29 @@
 
 <p>Here is an example of how to implement a Live Tile and update it from remote JavaScript:</p>
 
-<p>```javascript
+<p><code>javascript
 	function updateTile(message, imgUrl, imgAlt) {
 	    // Namespace: Windows.UI.Notifications
-	    if (typeof Windows !== ‘undefined’&amp;&amp;
-	            typeof Windows.UI !== ‘undefined’ &amp;&amp;
-	            typeof Windows.UI.Notifications !== ‘undefined’) {</p>
-
-<pre><code>        var notifications = Windows.UI.Notifications,
-        tile = notifications.TileTemplateType.tileSquare150x150PeekImageAndText01,
-        tileContent = notifications.TileUpdateManager.getTemplateContent(tile),
-        tileText = tileContent.getElementsByTagName('text'),
-        tileImage = tileContent.getElementsByTagName('image');
-
-        tileText[0].appendChild(tileContent.createTextNode(message || 'Demo Message'));
-        tileImage[0].setAttribute('src', imgUrl || 'https://unsplash.it/150/150/?random');
-        tileImage[0].setAttribute('alt', imgAlt || 'Random demo image');
-
-        var tileNotification = new notifications.TileNotification(tileContent);
-        var currentTime = new Date();
-        tileNotification.expirationTime = new Date(currentTime.getTime() + 600 * 1000);
-        notifications.TileUpdateManager.createTileUpdaterForApplication().update(tileNotification);
-    } else {
-        //Alternative behavior
-    }
-} ```
-</code></pre>
+	    if (typeof Windows !== 'undefined'&amp;&amp;
+	            typeof Windows.UI !== 'undefined' &amp;&amp;
+	            typeof Windows.UI.Notifications !== 'undefined') {	
+	        var notifications = Windows.UI.Notifications,
+	        tile = notifications.TileTemplateType.tileSquare150x150PeekImageAndText01,
+	        tileContent = notifications.TileUpdateManager.getTemplateContent(tile),
+	        tileText = tileContent.getElementsByTagName('text'),
+	        tileImage = tileContent.getElementsByTagName('image');	
+	        tileText[0].appendChild(tileContent.createTextNode(message || 'Demo Message'));
+	        tileImage[0].setAttribute('src', imgUrl || 'https://unsplash.it/150/150/?random');
+	        tileImage[0].setAttribute('alt', imgAlt || 'Random demo image');	
+	        var tileNotification = new notifications.TileNotification(tileContent);
+	        var currentTime = new Date();
+	        tileNotification.expirationTime = new Date(currentTime.getTime() + 600 * 1000);
+	        notifications.TileUpdateManager.createTileUpdaterForApplication().update(tileNotification);
+	    } else {
+	        //Alternative behavior
+	    }
+	}
+</code></p>
 
 <p>This code will produce a tile that looks something like this:
 <img src="/WebAppsDocs/images/HWA_liveTile.png" /></p>

--- a/css/main.css
+++ b/css/main.css
@@ -400,5 +400,10 @@ img.horizontal-margin-auto
 }
 .grey-border
 {
-    border: 1px solid grey;
+    border: 1px solid gray;
+}
+
+.highlight 
+{
+    color: gray;
 }

--- a/en-US/win10/HWAfeatures.md
+++ b/en-US/win10/HWAfeatures.md
@@ -72,18 +72,15 @@ Here is an example of how to implement a Live Tile and update it from remote Jav
 	    // Namespace: Windows.UI.Notifications
 	    if (typeof Windows !== 'undefined'&&
 	            typeof Windows.UI !== 'undefined' &&
-	            typeof Windows.UI.Notifications !== 'undefined') {
-	
+	            typeof Windows.UI.Notifications !== 'undefined') {	
 	        var notifications = Windows.UI.Notifications,
 	        tile = notifications.TileTemplateType.tileSquare150x150PeekImageAndText01,
 	        tileContent = notifications.TileUpdateManager.getTemplateContent(tile),
 	        tileText = tileContent.getElementsByTagName('text'),
-	        tileImage = tileContent.getElementsByTagName('image');
-	
+	        tileImage = tileContent.getElementsByTagName('image');	
 	        tileText[0].appendChild(tileContent.createTextNode(message || 'Demo Message'));
 	        tileImage[0].setAttribute('src', imgUrl || 'https://unsplash.it/150/150/?random');
-	        tileImage[0].setAttribute('alt', imgAlt || 'Random demo image');
-	
+	        tileImage[0].setAttribute('alt', imgAlt || 'Random demo image');	
 	        var tileNotification = new notifications.TileNotification(tileContent);
 	        var currentTime = new Date();
 	        tileNotification.expirationTime = new Date(currentTime.getTime() + 600 * 1000);


### PR DESCRIPTION
Someone just pointed out that the code samples had an issue as well -- at quick glance looks like it was just that color was set to white (on white).